### PR TITLE
Update Python dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 1


### PR DESCRIPTION
This PR adds dependabot to this repository to keep our Python dependencies up-to-date.